### PR TITLE
Fall back to existing ID if none found

### DIFF
--- a/assets/assets.json
+++ b/assets/assets.json
@@ -1889,7 +1889,7 @@
     "cryptoCurrencyIconName": "itc"
   },
   "6410d4f6-959e-5071-9b28-5b2c35c61c38": {
-    "cryptoCompareId": "ITT"
+    "cryptoCompareId": "ITF"
   },
   "f7f27010-1968-5fb4-a34e-d7c6ccb415ee": {
     "cryptoCompareId": "IVY"
@@ -2058,9 +2058,9 @@
     "cryptoCompareId": "LIKE"
   },
   "c0ae47d5-f020-5ea8-9886-522d3af70845": {
-    "cryptoCompareId": "LINK",
+    "coinCapId": "chainlink",
     "coinGeckoId": "chainlink",
-    "coinCapId": "chainlink"
+    "cryptoCompareId": "LINK"
   },
   "da4dc0a1-a590-581f-b6ad-42640ee02d4e": {
     "cryptoCompareId": "LNK"
@@ -3037,9 +3037,9 @@
     "cryptoCompareId": "RVT"
   },
   "53306efd-fb16-5e9a-b6d0-fc0e9713da40": {
-    "cryptoCompareId": "DAI",
     "coinCapId": "dai",
-    "coinGeckoId": "dai"
+    "coinGeckoId": "dai",
+    "cryptoCompareId": "DAI"
   },
   "2fdbfe5d-5e3a-5fe0-bcaa-42810867d1e6": {
     "cryptoCompareId": "SALT"
@@ -3979,5 +3979,11 @@
   },
   "054843cc-b3b7-5724-8ca6-bc4bbb5f52bc": {
     "cryptoCompareId": "ZXC"
+  },
+  "e1f698bf-cb85-5405-b563-14774af14bf1": {
+    "cryptoCompareId": "MCD"
+  },
+  "10b38465-640c-509a-b047-8d9671a245ae": {
+    "coinGeckoId": "vechain-old-erc20"
   }
 }

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -1,8 +1,8 @@
 import { dirname, join } from 'path';
 import { promises as fs } from 'fs';
 import execa from 'execa';
-import { Asset, BASE_ASSETS, OUTPUT_PATH } from './constants';
-import { isValidToken } from './utils';
+import { Asset, BASE_ASSETS, OUTPUT_PATH, ParsedAsset } from './constants';
+import { isValidAsset, isValidToken } from './utils';
 
 const TOKEN_FILE_PATH = join(__dirname, '../tokens/eth.json');
 
@@ -41,6 +41,24 @@ const fetchEthereumTokens = async (): Promise<Asset[]> => {
  */
 export const getAssets = async (): Promise<Asset[]> => {
   return [...BASE_ASSETS, ...(await fetchEthereumTokens())];
+};
+
+/**
+ * Get parsed assets from the disk. If an asset is invalid, it is skipped.
+ *
+ * @return {Promise<Record<string, ParsedAsset>>}
+ */
+export const getParsedAssets = async (): Promise<Record<string, ParsedAsset>> => {
+  const json = await fs.readFile(OUTPUT_PATH, 'utf8');
+  const assets = JSON.parse(json) as Record<string, ParsedAsset>;
+
+  return Object.keys(assets).reduce<Record<string, ParsedAsset>>((object, key) => {
+    const asset = assets[key];
+    if (isValidAsset(asset)) {
+      object[key] = asset;
+    }
+    return object;
+  }, {});
 };
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { compareTwoStrings } from 'string-similarity';
-import { Asset, TOKEN_ASSET_SCHEMA } from './constants';
+import { Asset, ASSET_SCHEMA, ParsedAsset, TOKEN_ASSET_SCHEMA } from './constants';
 
 /**
  * Checks whether two strings are similar to each other, based on the Sørensen–Dice coefficient. Returns `true` if the
@@ -21,6 +21,16 @@ export const isSimilar = (first: string, second: string): boolean => {
  */
 export const isValidToken = (token: Asset): boolean => {
   return !TOKEN_ASSET_SCHEMA.validate(token).error;
+};
+
+/**
+ * Checks if the asset is a valid (parsed) asset according to the validation schema.
+ *
+ * @param {ParsedAsset} asset
+ * @return {boolean}
+ */
+export const isValidAsset = (asset: ParsedAsset): boolean => {
+  return !ASSET_SCHEMA.validate(asset).error;
 };
 
 /**


### PR DESCRIPTION
This makes sure manually added properties don't get overwritten on build. If an ID is different from the one fetched, it is still replaced by the new ID.